### PR TITLE
Fix argument delegation of convenience functions.

### DIFF
--- a/lorem/__init__.py
+++ b/lorem/__init__.py
@@ -35,12 +35,12 @@ __all__ = ['sentence', 'paragraph', 'text']
 
 
 def sentence(*args, **kwargs):
-    return _Lorem().sentence(*args, **kwargs)
+    return _Lorem(*args, **kwargs).sentence()
 
 
 def paragraph(*args, **kwargs):
-    return _Lorem().paragraph(*args, **kwargs)
+    return _Lorem(*args, **kwargs).paragraph()
 
 
 def text(*args, **kwargs):
-    return _Lorem().text(*args, **kwargs)
+    return _Lorem(*args, **kwargs).text()


### PR DESCRIPTION
I was hoping to use the convenience functions with the same parameters as is possible when directly instantiating `TextLorem()` objects, but I was surprised this doesn't work.

i.e. this doesn't work:
```python
import lorem
lorem.text(trange=(2, 2))
```

whereas this does:
```python
from lorem.text import TextLorem
TextLorem(trange=(2, 2)).text()
```

However, this looks like a mistake rather than intention, as the delegation of the parameters is already present in `__init__.py`, only the parameters are handed over to the methods of the `TextLorem` class, which don't take arguments.

My changes make the former work as well, which is more convenient and very slightly easier to read for one-time usage.
