### PR TITLE
Added typing information and fixed bug in `sentence`, `paragraph`, and `text` functions

### DIFF
--- a/lorem/__init__.py
+++ b/lorem/__init__.py
@@ -31,7 +31,7 @@ from typing import Tuple
 
 __author__ = 'Stefan Fischer'
 __email__ = 'sfischer13@ymail.com'
-__version__ = '0.1.1-testing'
+__version__ = '0.1.2'
 
 __all__ = ['sentence', 'paragraph', 'text']
 

--- a/lorem/__init__.py
+++ b/lorem/__init__.py
@@ -26,6 +26,8 @@ The project was initiated by Stefan Fischer.
 """
 
 from .text import TextLorem as _Lorem
+from collections.abc import Sequence
+from typing import Tuple
 
 __author__ = 'Stefan Fischer'
 __email__ = 'sfischer13@ymail.com'
@@ -34,13 +36,61 @@ __version__ = '0.1.1-testing'
 __all__ = ['sentence', 'paragraph', 'text']
 
 
-def sentence(*args, **kwargs):
-    return _Lorem(*args, **kwargs).sentence()
+def sentence(
+    wsep: str = ' ',
+    ssep: str = ' ',
+    psep: str = '\n\n',
+    srange: Tuple[int, int] = (4, 8),
+    prange: Tuple[int, int] = (5, 10),
+    trange: Tuple[int, int] = (3, 6),
+    words: Sequence[str] = None
+) -> str:
+    return _Lorem(
+        wsep=wsep,
+        ssep=ssep,
+        psesp=psep,
+        srange=srange,
+        prange=prange,
+        trange=trange,
+        words=words
+    ).sentence()
 
 
-def paragraph(*args, **kwargs):
-    return _Lorem(*args, **kwargs).paragraph()
+def paragraph(
+    wsep: str = ' ',
+    ssep: str = ' ',
+    psep: str = '\n\n',
+    srange: Tuple[int, int] = (4, 8),
+    prange: Tuple[int, int] = (5, 10),
+    trange: Tuple[int, int] = (3, 6),
+    words: Sequence[str] = None
+):
+    return _Lorem(
+        wsep=wsep,
+        ssep=ssep,
+        psesp=psep,
+        srange=srange,
+        prange=prange,
+        trange=trange,
+        words=words
+    ).paragraph()
 
 
-def text(*args, **kwargs):
-    return _Lorem(*args, **kwargs).text()
+def text(
+    wsep: str = ' ',
+    ssep: str = ' ',
+    psep: str = '\n\n',
+    srange: Tuple[int, int] = (4, 8),
+    prange: Tuple[int, int] = (5, 10),
+    trange: Tuple[int, int] = (3, 6),
+    words: Sequence[str] = None
+):
+    return _Lorem(
+        wsep=wsep,
+        ssep=ssep,
+        psesp=psep,
+        srange=srange,
+        prange=prange,
+        trange=trange,
+        words=words
+    ).text()

--- a/lorem/__init__.py
+++ b/lorem/__init__.py
@@ -24,10 +24,16 @@
 The project was initiated by Stefan Fischer.
 
 """
+import sys
 
+if sys.version_info.minor >= 9:
+    # INFO: See this for more info
+    # https://www.python.org/dev/peps/pep-0585/
+    from collections.abc import Sequence
+    Tuple = tuple
+else:
+    from typing import Tuple, Sequence
 from .text import TextLorem as _Lorem
-from collections.abc import Sequence
-from typing import Tuple
 
 __author__ = 'Stefan Fischer'
 __email__ = 'sfischer13@ymail.com'

--- a/lorem/__init__.py
+++ b/lorem/__init__.py
@@ -29,18 +29,18 @@ from .text import TextLorem as _Lorem
 
 __author__ = 'Stefan Fischer'
 __email__ = 'sfischer13@ymail.com'
-__version__ = '0.1.1'
+__version__ = '0.1.1-testing'
 
 __all__ = ['sentence', 'paragraph', 'text']
 
 
 def sentence(*args, **kwargs):
-    return _Lorem().sentence(*args, **kwargs)
+    return _Lorem(*args, **kwargs).sentence()
 
 
 def paragraph(*args, **kwargs):
-    return _Lorem().paragraph(*args, **kwargs)
+    return _Lorem(*args, **kwargs).paragraph()
 
 
 def text(*args, **kwargs):
-    return _Lorem().text(*args, **kwargs)
+    return _Lorem(*args, **kwargs).text()

--- a/lorem/text.py
+++ b/lorem/text.py
@@ -1,7 +1,6 @@
 import random
 
-from collections.abc import Sequence
-from typing import Tuple
+from . import Sequence, Tuple
 from .data import WORDS
 
 

--- a/lorem/text.py
+++ b/lorem/text.py
@@ -1,18 +1,20 @@
 import random
 
+from collections.abc import Sequence
+from typing import Tuple
 from .data import WORDS
 
 
 class TextLorem():
     def __init__(
         self,
-        wsep=' ',
-        ssep=' ',
-        psep='\n\n',
-        srange=(4, 8),
-        prange=(5, 10),
-        trange=(3, 6),
-        words=None
+        wsep: str = ' ',
+        ssep: str = ' ',
+        psep: str = '\n\n',
+        srange: Tuple[int, int] = (4, 8),
+        prange: Tuple[int, int] = (5, 10),
+        trange: Tuple[int, int] = (3, 6),
+        words: Sequence[str] = None
     ):
         self._wsep = wsep
         self._ssep = ssep
@@ -25,20 +27,20 @@ class TextLorem():
         else:
             self._words = WORDS
 
-    def sentence(self):
+    def sentence(self) -> str:
         n = random.randint(*self._srange)
         s = self._wsep.join(self._word() for _ in range(n))
         return s[0].upper() + s[1:] + '.'
 
-    def paragraph(self):
+    def paragraph(self) -> str:
         n = random.randint(*self._prange)
         p = self._ssep.join(self.sentence() for _ in range(n))
         return p
 
-    def text(self):
+    def text(self) -> str:
         n = random.randint(*self._trange)
         t = self._psep.join(self.paragraph() for _ in range(n))
         return t
 
-    def _word(self):
+    def _word(self) -> str:
         return random.choice(self._words)

--- a/lorem/text.py
+++ b/lorem/text.py
@@ -4,9 +4,16 @@ from .data import WORDS
 
 
 class TextLorem():
-    def __init__(self, wsep=' ', ssep=' ', psep='\n\n',
-                 srange=(4, 8), prange=(5, 10), trange=(3, 6),
-                 words=None):
+    def __init__(
+        self,
+        wsep=' ',
+        ssep=' ',
+        psep='\n\n',
+        srange=(4, 8),
+        prange=(5, 10),
+        trange=(3, 6),
+        words=None
+    ):
         self._wsep = wsep
         self._ssep = ssep
         self._psep = psep


### PR DESCRIPTION
This pull request will make this code only compatible with Python 3.5 and higher.  If you want to preserve backwards compatibility with older versions of Python, only include the first two commits of this pull request, https://github.com/sfischer13/python-lorem/commit/7175063ef9a5f8399ff3a9867ea05cbde2dc90c3 and https://github.com/sfischer13/python-lorem/pull/2/commits/592a9559a42ecb3b6e02db3e1a2a735a96ef78b5, in versions that you wish to preserve backwards compatibility.